### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- cgroup and igroup
-- refactor rendering in Printer for improved line handling
-- text width
-- optimize speed
+- New `cgroup` and `igroup` functions
+- Improve new line handling in printer
 
 ### Other
 
-- *(ci)* setup release-plz
-- update dependencies
-- rename `Out` to `Token`
-- benchmarks
+- Update dependencies
+- Add benchmarks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0](https://github.com/Wybxc/elegance/compare/v0.1.0...v0.2.0) - 2025-02-15
+
+### Added
+
+- cgroup and igroup
+- refactor rendering in Printer for improved line handling
+- text width
+- optimize speed
+
+### Other
+
+- *(ci)* setup release-plz
+- update dependencies
+- rename `Out` to `Token`
+- benchmarks

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,7 +174,7 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "elegance"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "criterion",
  "indoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elegance"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "A pretty-printing library for Rust with a focus on speed and compactness."
 license = "Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `elegance`: 0.1.0 -> 0.2.0 (⚠ API breaking changes)

### ⚠ `elegance` breaking changes

```text
--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/method_parameter_count_changed.ron

Failed in:
  elegance::core::Printer::scan_text now takes 3 parameters instead of 2, in /tmp/.tmpNj5Isl/elegance/src/core.rs:97
  elegance::core::Printer::scan_begin now takes 3 parameters instead of 2, in /tmp/.tmpNj5Isl/elegance/src/core.rs:119
  elegance::core::Printer::group now takes 4 parameters instead of 3, in /tmp/.tmpNj5Isl/elegance/src/helper.rs:105
  elegance::Printer::scan_text now takes 3 parameters instead of 2, in /tmp/.tmpNj5Isl/elegance/src/core.rs:97
  elegance::Printer::scan_begin now takes 3 parameters instead of 2, in /tmp/.tmpNj5Isl/elegance/src/core.rs:119
  elegance::Printer::group now takes 4 parameters instead of 3, in /tmp/.tmpNj5Isl/elegance/src/helper.rs:105
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/Wybxc/elegance/compare/v0.1.0...v0.2.0) - 2025-02-15

### Added

- cgroup and igroup
- refactor rendering in Printer for improved line handling
- text width
- optimize speed

### Other

- *(ci)* setup release-plz
- update dependencies
- rename `Out` to `Token`
- benchmarks
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).