### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/Wybxc/elegance/compare/v0.2.0...v0.2.1) - 2025-02-15
+
+### Other
+
+- add categories and keywords to Cargo.toml for better discoverability
+
 ## [0.2.0](https://github.com/Wybxc/elegance/compare/v0.1.0...v0.2.0) - 2025-02-15
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,7 +174,7 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "elegance"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "criterion",
  "indoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elegance"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "A pretty-printing library for Rust with a focus on speed and compactness."
 license = "Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `elegance`: 0.2.0 -> 0.2.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.1](https://github.com/Wybxc/elegance/compare/v0.2.0...v0.2.1) - 2025-02-15

### Other

- add categories and keywords to Cargo.toml for better discoverability
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).