### PR TITLE
chore: release v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2](https://github.com/Wybxc/elegance/compare/v0.3.1...v0.3.2) - 2025-03-07
+
+### Added
+
+- add unicode-width feature for accurate Unicode character width calculation
+
 ## [0.3.1](https://github.com/Wybxc/elegance/compare/v0.3.0...v0.3.1) - 2025-03-07
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,7 +174,7 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "elegance"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "criterion",
  "indoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elegance"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 description = "A pretty-printing library for Rust with a focus on speed and compactness."
 license = "Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `elegance`: 0.3.1 -> 0.3.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.2](https://github.com/Wybxc/elegance/compare/v0.3.1...v0.3.2) - 2025-03-07

### Added

- add unicode-width feature for accurate Unicode character width calculation
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).