### PR TITLE
chore: release v0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.3](https://github.com/Wybxc/elegance/compare/v0.3.2...v0.3.3) - 2025-10-17
+
+### Other
+
+- update dependencies
+
 ## [0.3.2](https://github.com/Wybxc/elegance/compare/v0.3.1...v0.3.2) - 2025-03-07
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elegance"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "criterion",
  "indoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elegance"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 description = "A pretty-printing library for Rust with a focus on speed and compactness."
 license = "Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `elegance`: 0.3.2 -> 0.3.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.3](https://github.com/Wybxc/elegance/compare/v0.3.2...v0.3.3) - 2025-10-17

### Other

- update dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).