### PR TITLE
chore: release v0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.4](https://github.com/Wybxc/elegance/compare/v0.3.3...v0.3.4) - 2025-12-13
+
+### Added
+
+- add more tests for coverage
+
+### Fixed
+
+- update example return types in Printer methods to std::convert::Infallible
+- update error type in Render trait implementations to std::convert::Infallible
+
+### Other
+
+- update dependencies
+
 ## [0.3.3](https://github.com/Wybxc/elegance/compare/v0.3.2...v0.3.3) - 2025-10-17
 
 ### Other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,61 +5,64 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+<!-- markdownlint-disable MD024 -->
+
 ## [Unreleased]
 
 ## [0.3.4](https://github.com/Wybxc/elegance/compare/v0.3.3...v0.3.4) - 2025-12-13
 
-### Added
+### Changed
 
-- add more tests for coverage
-
-### Fixed
-
-- update example return types in Printer methods to std::convert::Infallible
-- update error type in Render trait implementations to std::convert::Infallible
-
-### Other
-
-- update dependencies
+- `Render` trait implementations for `String` and `OsString` now use `std::convert::Infallible` as the error type, as these writers cannot fail.
 
 ## [0.3.3](https://github.com/Wybxc/elegance/compare/v0.3.2...v0.3.3) - 2025-10-17
 
-### Other
+### Changed
 
-- update dependencies
+- Dependency updates.
 
 ## [0.3.2](https://github.com/Wybxc/elegance/compare/v0.3.1...v0.3.2) - 2025-03-07
 
 ### Added
 
-- add unicode-width feature for accurate Unicode character width calculation
+- `unicode-width` feature for accurate Unicode character width calculation (enabled by default).
 
 ## [0.3.1](https://github.com/Wybxc/elegance/compare/v0.3.0...v0.3.1) - 2025-03-07
 
-### Added
+### Changed
 
-- update text_owned method to accept any type convertible to S
+- `Printer::text_owned` now accepts any type implementing `Into<S>` instead of just `S`.
 
 ## [0.3.0](https://github.com/Wybxc/elegance/compare/v0.2.1...v0.3.0) - 2025-03-07
 
 ### Added
 
-- [**breaking**] custom string type
+- Generic string storage type `S` for `Printer<'a, R, S>`.
+- `Printer::new_with` constructor for custom string types.
+- `text_owned` method to handle owned strings and types convertible to `S`.
+- Public `string` module exposing `CowString` for borrowed/owned text handling.
+
+### Removed
+
+- `Printer::text` no longer accepts owned types; use `text_owned` instead.
 
 ## [0.2.1](https://github.com/Wybxc/elegance/compare/v0.2.0...v0.2.1) - 2025-02-15
 
-### Other
+### Changed
 
-- add categories and keywords to Cargo.toml for better discoverability
+- Added crates.io categories and keywords for better discoverability.
 
 ## [0.2.0](https://github.com/Wybxc/elegance/compare/v0.1.0...v0.2.0) - 2025-02-15
 
 ### Added
 
-- New `cgroup` and `igroup` functions
-- Improve new line handling in printer
+- `cgroup` method for consistent indented groups (all breaks align after first wrap).
+- `igroup` method for inconsistent indented groups (breaks continue flowing after first wrap).
 
-### Other
+### Removed
 
-- Update dependencies
-- Add benchmarks
+- `group` method no longer exists; use `cgroup` or `igroup` instead (they require explicit `consistent` parameter).
+
+### Changed
+
+- Improved line-breaking algorithm to handle multiple consecutive breaks and spacing more predictably.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,7 +192,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elegance"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "criterion",
  "indoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elegance"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 description = "A pretty-printing library for Rust with a focus on speed and compactness."
 license = "Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `elegance`: 0.3.3 -> 0.3.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.4](https://github.com/Wybxc/elegance/compare/v0.3.3...v0.3.4) - 2025-12-13

### Added

- add more tests for coverage

### Fixed

- update example return types in Printer methods to std::convert::Infallible
- update error type in Render trait implementations to std::convert::Infallible

### Other

- update dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).