### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/Wybxc/elegance/compare/v0.3.4...v0.4.0) - 2026-01-12
+
+### Added
+
+- custom extra data in printer
+
 ## [0.3.4](https://github.com/Wybxc/elegance/compare/v0.3.3...v0.3.4) - 2025-12-13
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,7 +192,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elegance"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "criterion",
  "indoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elegance"
-version = "0.3.4"
+version = "0.4.0"
 edition = "2021"
 description = "A pretty-printing library for Rust with a focus on speed and compactness."
 license = "Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `elegance`: 0.3.4 -> 0.4.0 (⚠ API breaking changes)

### ⚠ `elegance` breaking changes

```text
--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/method_parameter_count_changed.ron

Failed in:
  elegance::core::Printer::new_with now takes 3 parameters instead of 2, in /tmp/.tmpHTmiXo/elegance/src/core.rs:100
  elegance::Printer::new_with now takes 3 parameters instead of 2, in /tmp/.tmpHTmiXo/elegance/src/core.rs:100
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.0](https://github.com/Wybxc/elegance/compare/v0.3.4...v0.4.0) - 2026-01-12

### Added

- custom extra data in printer
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).