### PR TITLE
chore: release v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/Wybxc/elegance/compare/v0.4.0...v0.4.1) - 2026-02-26
+
+### Other
+
+- Fix typos (Walder -> Wadler) ([#10](https://github.com/Wybxc/elegance/pull/10))
+
 ## [0.4.0](https://github.com/Wybxc/elegance/compare/v0.3.4...v0.4.0) - 2026-01-12
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,7 +192,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elegance"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "criterion",
  "indoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elegance"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 description = "A pretty-printing library for Rust with a focus on speed and compactness."
 license = "Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `elegance`: 0.4.0 -> 0.4.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.1](https://github.com/Wybxc/elegance/compare/v0.4.0...v0.4.1) - 2026-02-26

### Other

- Fix typos (Walder -> Wadler) ([#10](https://github.com/Wybxc/elegance/pull/10))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).